### PR TITLE
Usunięcie volume img

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ SHOW TABLES;
 
 ```bash
 # Plik dump.sql można zamienić na inną lokalizację, dostaniemy ten plik lokalnie a nie w kontenerze
-# Jeśli chce się zapisać również zdjęcia, należy zzipować katalog shop/img/ i plik zip umieścić w shop/tmp/
+# Jeśli chce się zapisać również zdjęcia, należy zzipować katalog \\wsl$\docker-desktop-data\data\docker\volumes\shop_psdata\_data\img i plik zip umieścić w shop/tmp/
 docker exec shop-db-1 /bin/mysqldump -padmin presta > dump.sql
 ```
 

--- a/shop/docker-compose.yaml
+++ b/shop/docker-compose.yaml
@@ -53,8 +53,6 @@ services:
         # target:  /var/www/html/themes/myTheme # path to be mounted in the container
       - psdata:/var/www/html
       - etc:/etc
-      #- img:/var/www/html/img
-      # u mnie są błędy jak to jest mam 404 na serwerze, do sprawdzenia
 
 networks:
   presta_network:
@@ -63,10 +61,4 @@ volumes:
   psdata:
   dbdata:
   etc:
-  img:
-    driver: local
-    driver_opts:
-      o: bind
-      type: none
-      device: ./img
 


### PR DESCRIPTION
Ten volume i tak nie był konieczny, więc skoro powoduje problemy (jeśli już istnieje, jak się usunie jego zawartość, to działa poprawnie), to zamiast tego poprawiłem dokumentację - wskazałem lokalizację folderu do zzipowania
Closes #17 